### PR TITLE
Updates fadeout for space and responsiveness

### DIFF
--- a/css/gatsby.css
+++ b/css/gatsby.css
@@ -80,7 +80,7 @@ a:hover {
 .articlesList ul {
   list-style: none;
   padding-left: 15px;
-  max-height: 10vh;
+  height: 11em;
   overflow-y: scroll;
   text-transform: capitalize;
   width: auto;
@@ -109,33 +109,18 @@ input.searchBar {
 }
 .articlesList {
   overflow: hidden;
-  margin-bottom: -4%;
+  margin-bottom: -2em;
 }
 .fadeout {
-  position: relative; 
-  bottom: 4em;
-  height: 4em;
-  background: -webkit-linear-gradient(
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 1) 100%
-  ); 
-  background-image: -moz-linear-gradient(
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 1) 100%
-  );
-  background-image: -o-linear-gradient(
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 1) 100%
-  );
-  background-image: linear-gradient(
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 1) 100%
-  );
-  background-image: -ms-linear-gradient(
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 1) 100%
-  );
-} 
+  position: relative;
+  bottom: 2.5em;
+  height: 1.5em;
+  background: -webkit-linear-gradient( rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  background-image: -moz-linear-gradient( rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  background-image: -o-linear-gradient( rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  background-image: linear-gradient( rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+  background-image: -ms-linear-gradient( rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+}
 ::-webkit-input-placeholder {
   /* WebKit, Blink, Edge */
   color: darkgreen;
@@ -153,9 +138,4 @@ input.searchBar {
 :-ms-input-placeholder {
   /* Internet Explorer 10-11 */
   color: darkgreen;
-}
-@media (max-width:480px) {
-  .articlesList ul {
-    max-height: 20vh;
-  }
 }


### PR DESCRIPTION
## Changes:
- Makes fade effect responsive, looks better on mobile.
- Makes the fade area smaller enough so it is visible, but not big enough that it covers the bottom half of the link on top which should solve #44 
- Smaller fade area means more surface to scroll with mouse/mousepad or touch so that should help with #45 
## Solves:

Closes #51
Closes #45 
Closes #44
## Preview:
# Desktop View

![Desktop View](http://i.imgur.com/AlEOmMh.png)
![Desktop Side Bar](http://i.imgur.com/RFnxR7I.png)
# Mobile View

![Mobile Portrait](http://i.imgur.com/jgxczCC.png)
![Mobile Landscape](http://i.imgur.com/xDqWKDG.png)
![Mobile Landscape 2](http://i.imgur.com/EOOtk0t.png)
